### PR TITLE
solucion error al imprimir despues de un credito sin factura

### DIFF
--- a/application/src/routes.php
+++ b/application/src/routes.php
@@ -1223,6 +1223,7 @@ case "120": // mostar los botones imprimir factura
 
 // elimino las dos variables
 unset($_SESSION["factura_actual_print"], $_SESSION["cambio_actual_print"], $_SESSION["orden_actual_print"]);
+if(isset($_SESSION['aplicar_credito_sin_factura'])) unset($_SESSION['aplicar_credito_sin_factura']);
 break;
 
 
@@ -2697,6 +2698,7 @@ if (!isset($_SESSION['aplicar_credito_sin_factura'])) {
 
 // elimino las dos variables
 unset($_SESSION["factura_actual_print"], $_SESSION["cambio_actual_print"]);
+if(isset($_SESSION['aplicar_credito_sin_factura'])) unset($_SESSION['aplicar_credito_sin_factura']);
 break;
 
 


### PR DESCRIPTION
Se soluciona el error que después de hacer un crédito sin factura al facturar normalmente no imprime